### PR TITLE
add 'live calendar' button the the went home dialog

### DIFF
--- a/app/components/WentHomeDialog.tsx
+++ b/app/components/WentHomeDialog.tsx
@@ -4,6 +4,7 @@ import {
   DialogActions,
   Button,
   Typography,
+  Box,
 } from "@mui/material";
 import FavoriteIcon from "@mui/icons-material/Favorite";
 import { WHDCPropsType } from "@/types";
@@ -11,6 +12,7 @@ import { WHDCPropsType } from "@/types";
 export default function WentHomeDialogComponent({
   wentHomeDialog,
   setWentHomeDialog,
+  setStaticVersion,
 }: WHDCPropsType) {
   return (
     <Dialog
@@ -50,15 +52,35 @@ export default function WentHomeDialogComponent({
         </Typography>
       </DialogContent>
       <DialogActions>
-        <Button
-          onClick={() => {
-            setWentHomeDialog(false);
+        <Box
+          sx={{
+            display: "flex",
+            justifyContent: "space-between",
+            width: "100%",
           }}
-          color="primary"
-          variant="contained"
         >
-          WooHoo!!
-        </Button>
+          <Button
+            onClick={() => {
+              setWentHomeDialog(false);
+              setStaticVersion(false);
+              localStorage.setItem("staticVersion", "false");
+            }}
+            color="success"
+            variant="contained"
+          >
+            Live Calendar
+          </Button>
+
+          <Button
+            onClick={() => {
+              setWentHomeDialog(false);
+            }}
+            color="primary"
+            variant="contained"
+          >
+            WooHoo!!
+          </Button>
+        </Box>
       </DialogActions>
     </Dialog>
   );

--- a/app/components/calendar/RenderCalendarOrStaticCalendar.tsx
+++ b/app/components/calendar/RenderCalendarOrStaticCalendar.tsx
@@ -12,6 +12,7 @@ export default function CalendarOrStaticCalendar({
   readyToRenderCalendar,
   isDOMReady,
   staticVersion,
+  setStaticVersion,
   wentHomeDialog,
   setWentHomeDialog,
 }: RCOSCPropsType) {
@@ -25,6 +26,7 @@ export default function CalendarOrStaticCalendar({
               <WentHomeDialogComponent
                 wentHomeDialog={wentHomeDialog}
                 setWentHomeDialog={setWentHomeDialog}
+                setStaticVersion={setStaticVersion}
               />
             </FadeInWrapper>
           )}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -48,6 +48,7 @@ export default function Home() {
         readyToRenderCalendar={readyToRenderCalendar}
         isDOMReady={isDOMReady}
         staticVersion={staticVersion}
+        setStaticVersion={setStaticVersion}
         wentHomeDialog={wentHomeDialog}
         setWentHomeDialog={setWentHomeDialog}
       />

--- a/types/index.ts
+++ b/types/index.ts
@@ -43,6 +43,7 @@ export interface RCOSCPropsType {
   readyToRenderCalendar: boolean;
   isDOMReady: boolean;
   staticVersion: boolean;
+  setStaticVersion: Dispatch<SetStateAction<boolean>>;
   wentHomeDialog: boolean;
   setWentHomeDialog: Dispatch<SetStateAction<boolean>>;
 }
@@ -68,6 +69,7 @@ export interface ETBCPropsType {
 export interface WHDCPropsType {
   wentHomeDialog: boolean;
   setWentHomeDialog: Dispatch<SetStateAction<boolean>>;
+  setStaticVersion: Dispatch<SetStateAction<boolean>>;
 }
 
 //StaticCalendar.tsx


### PR DESCRIPTION
so you can easily switch to live calendar without first having to close the 'went home' dialog, then open the 'how to' dialog to find the button